### PR TITLE
fix: 容器模式下探测失败时回退到磁盘状态进行启动判断

### DIFF
--- a/internal/handler/handler.go
+++ b/internal/handler/handler.go
@@ -498,6 +498,7 @@ func StartRunner(c echo.Context) error {
 	if info == nil {
 		return echo.NewHTTPError(http.StatusNotFound, "未找到该 runner")
 	}
+	originalStatus := info.Status
 	probeFailed := false
 	if cfg.Runners.ContainerMode {
 		applyContainerStatusOne(c.Request().Context(), cfg, info)
@@ -506,8 +507,13 @@ func StartRunner(c echo.Context) error {
 			log.Printf("[start] 容器 Runner 状态探测失败 name=%s，将继续尝试启动: %v", info.Name, info.Probe.Error)
 		}
 	}
-	if info.Status != runner.StatusInstalled {
-		return echo.NewHTTPError(http.StatusBadRequest, "仅已注册的 runner 可启动，当前状态: "+string(info.Status))
+	// 容器模式下探测失败会把状态标记为 unknown；启动前资格判断应回退到磁盘原始状态。
+	startStatus := info.Status
+	if probeFailed {
+		startStatus = originalStatus
+	}
+	if startStatus != runner.StatusInstalled {
+		return echo.NewHTTPError(http.StatusBadRequest, "仅已注册的 runner 可启动，当前状态: "+string(startStatus))
 	}
 	if info.Running {
 		return c.JSON(http.StatusOK, map[string]any{"message": "Runner 已在运行中"})

--- a/internal/handler/handler_test.go
+++ b/internal/handler/handler_test.go
@@ -164,3 +164,48 @@ func TestUpdateRunner_TrimmedBodyNameAccepted(t *testing.T) {
 		t.Errorf("expected 200 when body name trims to URL name, got %d body=%s", rec.Code, rec.Body.String())
 	}
 }
+
+func TestStartRunner_ProbeFailureFallsBackToInstalledStatus(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	installDir := filepath.Join(dir, "r1")
+	if err := os.MkdirAll(installDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	// 标记为已注册状态
+	if err := os.WriteFile(filepath.Join(installDir, ".runner"), []byte("ok"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.Config{
+		Runners: config.RunnersConfig{
+			BasePath:      dir,
+			ContainerMode: true,
+			Items: []config.RunnerItem{
+				{Name: "r1", TargetType: "org", Target: "o1"},
+			},
+		},
+	}
+	if err := cfg.Save(cfgPath); err != nil {
+		t.Fatal(err)
+	}
+
+	oldConfigPath := ConfigPath
+	ConfigPath = cfgPath
+	defer func() { ConfigPath = oldConfigPath }()
+
+	// 让容器状态探测失败（docker 命令不可执行）
+	t.Setenv("PATH", "")
+	// 启动阶段走容器模式快速失败分支：若到达此处说明没有被 400 提前拦截
+	t.Setenv("DOCKER_HOST", "tcp://runner-dind:2375")
+
+	e := echo.New()
+	e.POST("/api/runners/:name/start", StartRunner)
+	req := httptest.NewRequest(http.MethodPost, "/api/runners/r1/start", nil)
+	rec := httptest.NewRecorder()
+	e.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500 when start is attempted after probe failure, got %d body=%s", rec.Code, rec.Body.String())
+	}
+}


### PR DESCRIPTION
## 改动内容

在容器模式下，当 `applyContainerStatusOne()` 探测失败时会将状态标记为 unknown，但这不应阻止启动操作——因为磁盘上的 runner 可能实际上已经注册过了。

### 具体改动：
- 在 `StartRunner` 中探测前保存 `originalStatus`
- 若 `probeFailed`，则使用 `originalStatus` 进行启动资格判断
- 新增测试 `TestStartRunner_ProbeFailureFallsBackToInstalledStatus` 验证该边界场景

Closes #1